### PR TITLE
feat: adEvent queue sync and bump to 1.0.8

### DIFF
--- a/Sources/adadapted-swift-sdk/constants/Config.swift
+++ b/Sources/adadapted-swift-sdk/constants/Config.swift
@@ -7,7 +7,7 @@ import Foundation
 class Config {
     internal static var isProd = false
 
-    static let LIBRARY_VERSION: String = "1.0.7"
+    static let LIBRARY_VERSION: String = "1.0.8"
     static let LOG_TAG = "ADADAPTED_SWIFT_SDK"
     static let DEFAULT_AD_POLLING = 300000 // If the new Ad polling isn't set it will default to every 5 minutes
     static let DEFAULT_EVENT_POLLING = 3000 // Events will be pushed to the server every 3 seconds

--- a/Sources/adadapted-swift-sdk/core/event/EventClient.swift
+++ b/Sources/adadapted-swift-sdk/core/event/EventClient.swift
@@ -14,6 +14,7 @@ class EventClient: SessionListener {
     private static var session: Session? = nil
     private static var hasInstance: Bool = false
     private static let sdkEventsQueue = DispatchQueue(label: "com.adadapted.sdkEventsQueue")
+    private static let adEventsQueue = DispatchQueue(label: "com.adadapted.adEventsQueue")
     
     private static func performTrackSdkEvent(name: String, params: [String: String]) {
         sdkEvents.insert(SdkEvent(type: EventStrings.SDK_EVENT_TYPE, name: name, params: params))
@@ -67,7 +68,11 @@ class EventClient: SessionListener {
             impressionId: ad.impressionId,
             eventType: eventType
         )
-        adEvents.insert(event)
+        
+        _ = adEventsQueue.sync {
+            adEvents.insert(event)
+        }
+        
         notifyAdEventTracked(event: event)
     }
     


### PR DESCRIPTION
- Updating adEvents queue to be properly synced for simultaneous access on multiple zone setups.
- Bump to 1.0.8