### PR TITLE
fix: resolving issue with blank ad html loading and occasionally crashing and bump to 1.0.9

### DIFF
--- a/Sources/adadapted-swift-sdk/constants/Config.swift
+++ b/Sources/adadapted-swift-sdk/constants/Config.swift
@@ -7,7 +7,7 @@ import Foundation
 class Config {
     internal static var isProd = false
 
-    static let LIBRARY_VERSION: String = "1.0.8"
+    static let LIBRARY_VERSION: String = "1.0.9"
     static let LOG_TAG = "ADADAPTED_SWIFT_SDK"
     static let DEFAULT_AD_POLLING = 300000 // If the new Ad polling isn't set it will default to every 5 minutes
     static let DEFAULT_EVENT_POLLING = 3000 // Events will be pushed to the server every 3 seconds

--- a/Sources/adadapted-swift-sdk/core/view/AdWebView.swift
+++ b/Sources/adadapted-swift-sdk/core/view/AdWebView.swift
@@ -47,13 +47,15 @@ class AdWebView: WKWebView, WKNavigationDelegate, UIGestureRecognizerDelegate {
             }
         }
     }
-
+    
     func loadBlank() {
         currentAd = Ad()
         let dummyDocument = """
             <html><head><meta name="viewport" content="width=device-width, user-scalable=no" /></head><body></body></html>
         """
-        loadHTMLString(dummyDocument, baseURL: nil)
+        DispatchQueue.main.async { [weak self] in
+            self?.loadHTMLString(dummyDocument, baseURL: nil)
+        }
         notifyBlankLoaded()
     }
 


### PR DESCRIPTION
- Fix for blank ads occasionally crashing.
- Update to 1.0.9