### PR TITLE
feat: reverting listmanager swap for items and lists

### DIFF
--- a/Sources/adadapted-swift-sdk/constants/Config.swift
+++ b/Sources/adadapted-swift-sdk/constants/Config.swift
@@ -7,7 +7,7 @@ import Foundation
 class Config {
     internal static var isProd = false
 
-    static let LIBRARY_VERSION: String = "1.0.9"
+    static let LIBRARY_VERSION: String = "1.0.10"
     static let LOG_TAG = "ADADAPTED_SWIFT_SDK"
     static let DEFAULT_AD_POLLING = 300000 // If the new Ad polling isn't set it will default to every 5 minutes
     static let DEFAULT_EVENT_POLLING = 3000 // Events will be pushed to the server every 3 seconds

--- a/Sources/adadapted-swift-sdk/core/AdAdaptedListManager.swift
+++ b/Sources/adadapted-swift-sdk/core/AdAdaptedListManager.swift
@@ -8,7 +8,7 @@ public class AdAdaptedListManager {
     static let LIST_NAME = "list_name"
     static let ITEM_NAME = "item_name"
     
-    public static func itemAddedToList(item: String, list: String = "") {
+    public static func itemAddedToList(list: String = "", item: String) {
         if (item.isEmpty) {
             return
         }
@@ -16,7 +16,7 @@ public class AdAdaptedListManager {
         AALogger.logInfo(message: "\(item) was added to \(list)")
     }
     
-    public static func itemCrossedOffList(item: String, list: String = "") {
+    public static func itemCrossedOffList(list: String = "", item: String) {
         if (item.isEmpty) {
             return
         }
@@ -24,7 +24,7 @@ public class AdAdaptedListManager {
         AALogger.logInfo(message: "\(item) was crossed off \(list)")
     }
     
-    public static func itemDeletedFromList(item: String, list: String = "") {
+    public static func itemDeletedFromList(list: String = "", item: String) {
         if (item.isEmpty) {
             return
         }

--- a/Tests/adadapted-swift-sdkTests/addit/AdAdaptedListManagerTests.swift
+++ b/Tests/adadapted-swift-sdkTests/addit/AdAdaptedListManagerTests.swift
@@ -46,7 +46,7 @@ class AdAdaptedListManagerTest: XCTestCase {
 
     func testItemAddedToListWithList() {
         let expectation = XCTestExpectation(description: "Content available expectation")
-        AdAdaptedListManager.itemAddedToList(item: "TestItem", list: "TestList")
+        AdAdaptedListManager.itemAddedToList(list: "TestList", item: "TestItem")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             EventClient.getInstance().onPublishEvents()
         }
@@ -79,7 +79,7 @@ class AdAdaptedListManagerTest: XCTestCase {
 
     func testItemCrossedOffListWithList() {
         let expectation = XCTestExpectation(description: "Content available expectation")
-        AdAdaptedListManager.itemCrossedOffList(item: "TestItem", list: "TestList")
+        AdAdaptedListManager.itemCrossedOffList(list: "TestList", item: "TestItem")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             EventClient.getInstance().onPublishEvents()
         }
@@ -112,7 +112,7 @@ class AdAdaptedListManagerTest: XCTestCase {
 
     func testItemDeletedFromListWithList() {
         let expectation = XCTestExpectation(description: "Content available expectation")
-        AdAdaptedListManager.itemDeletedFromList(item: "TestItem", list: "TestList")
+        AdAdaptedListManager.itemDeletedFromList(list: "TestList", item: "TestItem")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
             EventClient.getInstance().onPublishEvents()
         }


### PR DESCRIPTION
- Reverting the order of the list manager event to take the list first followed by the item.
- Bump to 1.0.10