### PR TITLE
feat: deduplication for content listeners 1.1.2

### DIFF
--- a/Sources/adadapted-swift-sdk/constants/Config.swift
+++ b/Sources/adadapted-swift-sdk/constants/Config.swift
@@ -7,7 +7,7 @@ import Foundation
 class Config {
     internal static var isProd = false
 
-    static let LIBRARY_VERSION: String = "1.1.1"
+    static let LIBRARY_VERSION: String = "1.1.2"
     static let LOG_TAG = "ADADAPTED_SWIFT_SDK"
     static let DEFAULT_AD_POLLING = 300000 // If the new Ad polling isn't set it will default to every 5 minutes
     static let DEFAULT_EVENT_POLLING = 3000 // Events will be pushed to the server every 3 seconds

--- a/Sources/adadapted-swift-sdk/core/ad/AdContentPublisher.swift
+++ b/Sources/adadapted-swift-sdk/core/ad/AdContentPublisher.swift
@@ -17,7 +17,9 @@ class AdContentPublisher {
     private var listeners: Array<AdContentListener> = []
     
     func addListener(listener: AdContentListener) {
-        listeners.insert(listener, at: 0)
+        if !listeners.contains(where: { $0.listenerId == listener.listenerId }) {
+            listeners.append(listener)
+        }
     }
     
     func removeListener(listener: AdContentListener) {


### PR DESCRIPTION
- Single content listeners for all zones is now eligible.
- Bump to 1.1.2