### PR TITLE
feat: updating thread safety for event queues and bump for 1.1.6

### DIFF
--- a/Sources/adadapted-swift-sdk/constants/Config.swift
+++ b/Sources/adadapted-swift-sdk/constants/Config.swift
@@ -7,7 +7,7 @@ import Foundation
 class Config {
     internal static var isProd = false
 
-    static let LIBRARY_VERSION: String = "1.1.5"
+    static let LIBRARY_VERSION: String = "1.1.6"
     static let LOG_TAG = "ADADAPTED_SWIFT_SDK"
     static let DEFAULT_AD_POLLING = 300000 // If the new Ad polling isn't set it will default to every 5 minutes
     static let DEFAULT_EVENT_POLLING = 3000 // Events will be pushed to the server every 3 seconds

--- a/Sources/adadapted-swift-sdk/core/event/EventClient.swift
+++ b/Sources/adadapted-swift-sdk/core/event/EventClient.swift
@@ -37,7 +37,6 @@ class EventClient: SessionListener {
         guard let currentSession = session,
               let adapter = eventAdapter,
               !sdkErrors.isEmpty else {
-            AALogger.logError(message: "Cannot publish sdk errors: Missing session, adapter, or events.")
             return
         }
         
@@ -55,7 +54,6 @@ class EventClient: SessionListener {
         guard let currentSession = session,
               let adapter = eventAdapter,
               !sdkEvents.isEmpty else {
-            AALogger.logError(message: "Cannot publish sdk events: Missing session, adapter, or events.")
             return
         }
         
@@ -73,7 +71,6 @@ class EventClient: SessionListener {
         guard let currentSession = session,
               let adapter = eventAdapter,
               !adEvents.isEmpty else {
-            AALogger.logError(message: "Cannot publish ad events: Missing session, adapter, or events.")
             return
         }
 

--- a/Sources/adadapted-swift-sdk/core/event/EventClient.swift
+++ b/Sources/adadapted-swift-sdk/core/event/EventClient.swift
@@ -13,8 +13,12 @@ class EventClient: SessionListener {
     private static var sdkErrors: Set<SdkError> = []
     private static var session: Session? = nil
     private static var hasInstance: Bool = false
-    private static let sdkEventsQueue = DispatchQueue(label: "com.adadapted.sdkEventsQueue")
-    private static let adEventsQueue = DispatchQueue(label: "com.adadapted.adEventsQueue")
+    private static let sdkErrorsQueue = DispatchQueue(label: "com.adadapted.sdkErrorsQueue", attributes: .concurrent)
+    private static let sdkEventsQueue = DispatchQueue(label: "com.adadapted.sdkEventsQueue", attributes: .concurrent)
+    private static let adEventsQueue = DispatchQueue(label: "com.adadapted.adEventsQueue", attributes: .concurrent)
+    private static let sdkErrorsLock = NSLock()
+    private static let adEventsLock = NSLock()
+    private static let sdkEventsLock = NSLock()
     
     private static func performTrackSdkEvent(name: String, params: [String: String]) {
         EventClient.sdkEventsQueue.async {
@@ -30,35 +34,56 @@ class EventClient: SessionListener {
     }
     
     private static func performPublishSdkErrors() {
-        guard let currentSession = session, !sdkErrors.isEmpty else {
+        guard let currentSession = session,
+              let adapter = eventAdapter,
+              !sdkErrors.isEmpty else {
+            AALogger.logError(message: "Cannot publish ad events: Missing session, adapter, or events.")
             return
         }
-        EventClient.sdkEventsQueue.async {
+        
+        sdkErrorsQueue.async(flags: .barrier) {
+            sdkErrorsLock.lock()
             let currentSdkErrors = Array(sdkErrors)
-            EventClient.sdkErrors.removeAll()
-            EventClient.eventAdapter?.publishSdkErrors(session: currentSession, errors: currentSdkErrors)
+            sdkErrors.removeAll()
+            sdkErrorsLock.unlock()
+            
+            adapter.publishSdkErrors(session: currentSession, errors: currentSdkErrors)
         }
     }
     
     private static func performPublishSdkEvents() {
-        EventClient.sdkEventsQueue.async {
-            guard let currentSession = session, !sdkEvents.isEmpty else {
-                return
-            }
-            let currentSdkEvents = Array(sdkEvents)
-            EventClient.sdkEvents.removeAll()
-            EventClient.eventAdapter?.publishSdkEvents(session: currentSession, events: currentSdkEvents)
-        }
-    }
-    
-    private static func performPublishAdEvents() {
-        guard let currentSession = session, !adEvents.isEmpty else {
+        guard let currentSession = session,
+              let adapter = eventAdapter,
+              !sdkEvents.isEmpty else {
+            AALogger.logError(message: "Cannot publish ad events: Missing session, adapter, or events.")
             return
         }
-        EventClient.adEventsQueue.async {
+        
+        sdkEventsQueue.async(flags: .barrier) {
+            sdkEventsLock.lock()
+            let currentSdkEvents = Array(sdkEvents)
+            sdkEvents.removeAll()
+            sdkEventsLock.unlock()
+            
+            adapter.publishSdkEvents(session: currentSession, events: currentSdkEvents)
+        }
+    }
+
+    private static func performPublishAdEvents() {
+        guard let currentSession = session,
+              let adapter = eventAdapter,
+              !adEvents.isEmpty else {
+            AALogger.logError(message: "Cannot publish ad events: Missing session, adapter, or events.")
+            return
+        }
+
+        adEventsQueue.async(flags: .barrier) {
+            adEventsLock.lock()
             let currentAdEvents = Array(adEvents)
-            EventClient.adEvents.removeAll()
-            EventClient.eventAdapter?.publishAdEvents(session: currentSession, adEvents: currentAdEvents)
+            adEvents.removeAll()
+            adEventsLock.unlock()
+
+            adapter.publishAdEvents(session: currentSession, adEvents: currentAdEvents)
         }
     }
     
@@ -106,11 +131,9 @@ class EventClient: SessionListener {
     }
     
     func onPublishEvents() {
-        EventClient.sdkEventsQueue.async {
-            EventClient.performPublishAdEvents()
-            EventClient.performPublishSdkEvents()
-            EventClient.performPublishSdkErrors()
-        }
+        EventClient.performPublishAdEvents()
+        EventClient.performPublishSdkEvents()
+        EventClient.performPublishSdkErrors()
     }
     
     static func hasBeenInitialized() -> Bool {

--- a/Sources/adadapted-swift-sdk/core/event/EventClient.swift
+++ b/Sources/adadapted-swift-sdk/core/event/EventClient.swift
@@ -37,7 +37,7 @@ class EventClient: SessionListener {
         guard let currentSession = session,
               let adapter = eventAdapter,
               !sdkErrors.isEmpty else {
-            AALogger.logError(message: "Cannot publish ad events: Missing session, adapter, or events.")
+            AALogger.logError(message: "Cannot publish sdk errors: Missing session, adapter, or events.")
             return
         }
         
@@ -55,7 +55,7 @@ class EventClient: SessionListener {
         guard let currentSession = session,
               let adapter = eventAdapter,
               !sdkEvents.isEmpty else {
-            AALogger.logError(message: "Cannot publish ad events: Missing session, adapter, or events.")
+            AALogger.logError(message: "Cannot publish sdk events: Missing session, adapter, or events.")
             return
         }
         


### PR DESCRIPTION
- Updated event queues to have individual queues, locks, and barriers for concurrent access in heavy use cases.
- Bump to version 1.1.6